### PR TITLE
#57 extract react boostrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,15 +28,11 @@
   },
   "homepage": "https://github.com/redux-autoform/redux-autoform#readme",
   "dependencies": {
-    "bootstrap": "^3.3.5",
-    "font-awesome": "^4.6.3",
     "react": "^15.1.0",
     "react-addons-update": "^15.2.1",
-    "react-bootstrap": "0.30.0",
     "react-dom": "^15.1.0",
     "react-redux": "^4.4.2",
     "redux": "^3.4.0",
-    "redux-autoform-bootstrap-ui": "^1.0.1",
     "redux-autoform-utils": "^1.0.3",
     "redux-form": "^5.2.5"
   },

--- a/src/AutoForm.js
+++ b/src/AutoForm.js
@@ -61,6 +61,7 @@ class AutoForm extends Component {
                 buttonBar,
                 fieldLayout
             };
+
             let reduxFormProps = {
                 form,
                 onSubmit,

--- a/src/AutoFormInternal.js
+++ b/src/AutoFormInternal.js
@@ -2,7 +2,6 @@ import React, { Component, PropTypes } from 'react'
 import { reduxForm } from 'redux-form';
 import metadataEvaluator from './metadata/evaluator/metadataEvaluator';
 import modelParser from './metadata/model/modelParser';
-import { Form } from 'react-bootstrap';
 import UIManager from './UIManager';
 
 class AutoFormInternal extends Component {
@@ -48,13 +47,15 @@ class AutoFormInternal extends Component {
     render() {
         let { handleSubmit, submitting, buttonBar, fieldLayout } = this.props;
         let groupComponent = this.buildGroupComponent();
-        
+
+        let className = (fieldLayout == 'inline')? "meta-form inline" : "meta-form";
+
         return (
-            <div className="meta-form">
-                <Form onSubmit={handleSubmit} horizontal={fieldLayout == 'inline'}>
+            <div className={className}>
+                <form onSubmit={handleSubmit}>
                     { groupComponent }
                     { React.createElement(buttonBar, { submitting: submitting }) }
-                </Form>
+                </form>
             </div>
         )
     }

--- a/src/AutoFormInternal.js
+++ b/src/AutoFormInternal.js
@@ -48,7 +48,9 @@ class AutoFormInternal extends Component {
         let { handleSubmit, submitting, buttonBar, fieldLayout } = this.props;
         let groupComponent = this.buildGroupComponent();
 
-        let className = (fieldLayout == 'inline')? "meta-form inline" : "meta-form";
+        //This works only with boostrap, non material-ui or any other ui framework because 'form-horizontal' is
+        //a set of classes for boostrap.
+        let className = (fieldLayout == 'inline')? "meta-form form-horizontal" : "meta-form";
 
         return (
             <div className={className}>


### PR DESCRIPTION
This PR intends to solve the issue #57. The changes I have made are the following ones: 
- Extract bootstrap and all it's dependencies from package.json
- Replace bootstrap built in Form component for normal form
- Added a conditional css to add the form-horizontal class if property fieldLayout is specified. 

@andrerpena I have opened this PR, because I want to discuss some thoughts I have during performing this changes. 

fieldLayout is intented for bootstrap, not? I was thinking that I could merge the layout prop that receives AutoFormInternal with fieldLayout, so, in the bootstrap-ui extension I can capture it and add the corresponding CSS class based on the prop received. 

What do you think? 
