### PR TITLE
Expression global scope

### DIFF
--- a/src/metadata/evaluator/MetadataEvaluator.js
+++ b/src/metadata/evaluator/MetadataEvaluator.js
@@ -40,23 +40,23 @@ class MetadataEvaluator {
      * @param onChange
      * @returns {{}}
      */
-    static evaluate(propertyMetadata, model, keyPrefix, reduxFieldProps, onChange) {
+    static evaluate(propertyMetadata, model, keyPrefix, reduxFieldProps, onChange, globalScope) {
         if (!propertyMetadata) throw Error('Argument \'propertyMetadata\' should be truthy');
         if (!model) throw Error('\'model\' should be truthy');
 
         if (propertyMetadata.constructor === Array) {
-            return propertyMetadata.map(i => this.evaluate(i, model, keyPrefix, reduxFieldProps, onChange));
+            return propertyMetadata.map(i => this.evaluate(i, model, keyPrefix, reduxFieldProps, onChange, globalScope));
         }
 
         let result = {};
 
         Object.keys(propertyMetadata).forEach((fieldName) => {
-            result[fieldName] = this.filterPropertyField(fieldName, propertyMetadata[fieldName], model);
+            result[fieldName] = this.filterPropertyField(fieldName, propertyMetadata[fieldName], model, globalScope);
         });
 
         let newPrefix = keyPrefix ? `${keyPrefix}.${propertyMetadata.name}` : propertyMetadata.name;
 
-        return this.filterProperty(result, model, newPrefix, reduxFieldProps, onChange);
+        return this.filterProperty(result, model, newPrefix, reduxFieldProps, onChange, globalScope);
     }
 
     /**
@@ -65,7 +65,7 @@ class MetadataEvaluator {
      * @param fieldValue
      * @param model
      */
-    static filterPropertyField(fieldName, fieldValue, model) {
+    static filterPropertyField(fieldName, fieldValue, model, globalScope) {
         let { fieldFilters } = this;
         let processedFieldValue = fieldValue;
 
@@ -74,7 +74,7 @@ class MetadataEvaluator {
             if (!fieldFilters[i].property || fieldFilters[i].property === fieldName) {
                 let filter = fieldFilters[i].filter;
 
-                processedFieldValue = filter(fieldName, processedFieldValue, model);
+                processedFieldValue = filter(fieldName, processedFieldValue, model, globalScope);
             }
         }
 
@@ -90,14 +90,14 @@ class MetadataEvaluator {
      * @param reduxProps
      * @returns {*}
      */
-    static filterProperty(metadata, model, keyPrefix, metadataIndex, reduxProps) {
+    static filterProperty(metadata, model, keyPrefix, metadataIndex, reduxProps, globalScope) {
         let { propertyFilters } = this;
         let processedMetadata = metadata;
 
         for (let i = 0; i < propertyFilters.length; i++) {
             let filter = propertyFilters[i];
 
-            processedMetadata = filter(processedMetadata, model, keyPrefix, this, metadataIndex, reduxProps);
+            processedMetadata = filter(processedMetadata, model, keyPrefix, this, metadataIndex, reduxProps, globalScope);
         }
 
         return processedMetadata;

--- a/src/metadata/evaluator/expression/ExpressionEvaluator.js
+++ b/src/metadata/evaluator/expression/ExpressionEvaluator.js
@@ -8,9 +8,8 @@ export default class ExpressionEvaluator {
      * @param data - the data scope in which the expression will be executed
      * @returns {Object}
      */
-    static evaluate(expression, data) {
+    static evaluate(expression, data, globalScope) {
         var _expressionHelper;
-
         switch (typeof expression) {
             case 'function':
                 try {
@@ -18,7 +17,7 @@ export default class ExpressionEvaluator {
                         _expressionHelper = getExpressionHelper();
                     }
 
-                    let evaluation = expression(data, _expressionHelper);
+                    let evaluation = expression(data, _expressionHelper, globalScope);
 
                     if (typeof evaluation === 'object' && evaluation != null) {
                         // React cannot render objects. Because of that, objects are converted to strings

--- a/src/metadata/evaluator/filter/Filters.js
+++ b/src/metadata/evaluator/filter/Filters.js
@@ -10,10 +10,11 @@ export default class Filters {
      * @param onChange
      * @returns {*}
      */
-    static arrayFilter(propertyMetadata, model, keyPrefix, metadataEvaluator, reduxProps, onChange) {
+    static arrayFilter(propertyMetadata, model, keyPrefix, metadataEvaluator, reduxProps, onChange, globalScope) {
 
         if(!propertyMetadata) throw Error('Argument \'propertyMetadata\' should be truthy');
         if(!model) throw Error('Argument \'model\' should be truthy');
+        if( !globalScope ) globalScope = model
 
         if (propertyMetadata.type == 'array' && propertyMetadata.arrayType == 'entity') {
             if (!propertyMetadata.fields) {
@@ -37,7 +38,7 @@ export default class Filters {
                 return reduxProps[propertyMetadata.name][index];
             };
 
-            propertyMetadata.fields = model[propertyMetadata.name].map((item, index) =>  metadataEvaluator.evaluate(propertyMetadata.fields, item, `${keyPrefix}.${index}`, getReduxPropsForItem(index), onChange));
+            propertyMetadata.fields = model[propertyMetadata.name].map((item, index) =>  metadataEvaluator.evaluate(propertyMetadata.fields, item, `${keyPrefix}.${index}`, getReduxPropsForItem(index), onChange, globalScope));
         }
         return propertyMetadata;
     }
@@ -52,7 +53,7 @@ export default class Filters {
      * @param onChange
      * @returns {*}
      */
-    static defaultFilter(propertyMetadata, model, keyPrefix, metadataEvaluator, reduxProps, onChange) {
+    static defaultFilter(propertyMetadata, model, keyPrefix, metadataEvaluator, reduxProps, onChange, globalScope) {
 
         if(!propertyMetadata) throw Error('Argument \'propertyMetadata\' should be truthy');
         if(!model) throw Error('Argument \'model\' should be truthy');
@@ -77,9 +78,10 @@ export default class Filters {
      * @param onChange
      * @returns {*}
      */
-    static entityFilter(propertyMetadata, model, keyPrefix, metadataEvaluator, reduxProps, onChange) {
+    static entityFilter(propertyMetadata, model, keyPrefix, metadataEvaluator, reduxProps, onChange, globalScope) {
         if (!propertyMetadata) throw new Error('metadata is required');
         if (!model) throw new Error('model is required');
+        if( !globalScope ) globalScope = model
 
         if (propertyMetadata.type == 'entity') {
 
@@ -98,7 +100,7 @@ export default class Filters {
             }
 
             let itemReduxProps = reduxProps ? reduxProps[propertyMetadata.name] : undefined;
-            propertyMetadata.fields = metadataEvaluator.evaluate(propertyMetadata.fields, model[propertyMetadata.name], keyPrefix, itemReduxProps, onChange);
+            propertyMetadata.fields = metadataEvaluator.evaluate(propertyMetadata.fields, model[propertyMetadata.name], keyPrefix, itemReduxProps, onChange, globalScope);
         }
 
         return propertyMetadata;

--- a/src/metadata/evaluator/filter/PropertyFilters.js
+++ b/src/metadata/evaluator/filter/PropertyFilters.js
@@ -9,14 +9,14 @@ export default class PropertyFilters {
      * @param model
      * @returns {*}
      */
-    static propertyFilter(propertyName, propertyValue, model) {
+    static propertyFilter(propertyName, propertyValue, model, globalScope) {
         if(!model) {
             throw new Error('model is required');
         }
 
         if (typeof(propertyValue) === "function" && propertyName.indexOf('$') != 0) {
             // do something
-            return ExpressionEvaluator.evaluate(propertyValue, model);
+            return ExpressionEvaluator.evaluate(propertyValue, model, globalScope);
         }
 
         return propertyValue;

--- a/test/MetadataEvaluatorSpec.js
+++ b/test/MetadataEvaluatorSpec.js
@@ -364,5 +364,69 @@ describe('MetadataEvaluator', function () {
                 ]
             }, '', reduxProps);
         });
+
+        it('Should have globalScope/rootModel as third param', function () {
+
+            let rootModel = {
+                person_address: {
+                    active: 'home',
+                    home: {
+                        city: "Nagpur"
+                    },
+                    office: {
+                        city: "Banglore"
+                    }
+                }
+            }
+
+            let rootScope_in_home_field,
+                rootScope_in_office_field;
+
+            let metadata = {
+                name: 'person_address',
+                type: 'entity',
+                fields: [
+                    {
+                        name: 'active'
+                    },
+                    {
+                        name: 'home',
+                        type: 'entity',
+                        entityName: 'address',
+                        visible: (model, formatter, globalScope)=>{
+                            rootScope_in_home_field = globalScope;
+                            return globalScope.person_address.active === 'home'
+                        },
+                        fields: [
+                            {
+                                name: 'city',
+                                type: 'string'
+                            },
+                        ]
+                    },
+                    {
+                        name: 'office',
+                        type: 'entity',
+                        entityName: 'address',
+                        visible: (model, formatter, globalScope)=>{
+                            rootScope_in_office_field = globalScope;
+                            return globalScope.person_address.active === 'office'
+                        },
+                        fields: [
+                            {
+                                name: 'city',
+                                type: 'string'
+                            }
+                        ]
+                    }
+                ]
+            };
+            let metadataIndex = {};
+            let metadataEvaluation = MetadataEvaluator.evaluate(metadata, rootModel, '', metadataIndex );
+
+            assert.equal( rootModel, rootScope_in_home_field );
+            assert.equal( rootModel, rootScope_in_office_field );
+
+        });
     });
 });


### PR DESCRIPTION
### This feature will provide global scope for an expression as a third param.

**Usecase:**
If we want to access rootModel in field expression,
which is nested deeply in rootModel then we can access it using this feature.
It will pass rootModel/globalScope as third parameter to expression evaluator.

Consider following rootModel:

```
           let rootModel = {
                person_address: {
                    active: 'home',
                    home: {
                        city: "Nagpur"
                    },
                    office: {
                        city: "Banglore"
                    }
                }
            }
```

Consider following metadata:

```
            let metadata = {
                name: 'person_address',
                type: 'entity',
                fields: [
                    {
                        name: 'active'
                    },
                    {
                        name: 'home',
                        type: 'entity',
                        entityName: 'address',
                        visible: (model, formatter, globalScope)=>{
                            return globalScope.person_address.active === 'home'
                        },
                        fields: [
                            {
                                name: 'city',
                                type: 'string'
                            },
                        ]
                    },
                    {
                        name: 'office',
                        type: 'entity',
                        entityName: 'address',
                        visible: (model, formatter, globalScope)=>{
                            return globalScope.person_address.active === 'office'
                        },
                        fields: [
                            {
                                name: 'city',
                                type: 'string'
                            }
                        ]
                    }
                ]
            };
```

Requirement is to set visible field 
1. person_address.home.visible = true or false as per person_address.active field
```
              visible: (model, formatter, globalScope)=>{
                   return globalScope.person_address.active === 'home'
              }
```
Above feature will support such requirements where we want rootModel access in nested field expression.

